### PR TITLE
endpoint actualizar cuenta con handle de errores

### DIFF
--- a/src/main/java/com/alkemy/paypocket/controllers/AccountController.java
+++ b/src/main/java/com/alkemy/paypocket/controllers/AccountController.java
@@ -5,12 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.alkemy.paypocket.dtos.AccountDto;
 import com.alkemy.paypocket.entities.Account;
@@ -39,5 +34,10 @@ public class AccountController {
 
         List<Account> userAccounts = accountService.findAllAccountByUser(id);
         return ResponseEntity.ok(userAccounts);
+    }
+
+    @PatchMapping(path = "/{account_id}")
+    public ResponseEntity<?> updateAccount(@PathVariable("account_id") Integer id, @RequestBody @Valid AccountDto accountDto, BindingResult result){
+        return ResponseEntity.ok(accountService.updateAccount(accountDto, id));
     }
 }

--- a/src/main/java/com/alkemy/paypocket/message/ResponseData.java
+++ b/src/main/java/com/alkemy/paypocket/message/ResponseData.java
@@ -1,0 +1,18 @@
+package com.alkemy.paypocket.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ResponseData<T> {
+
+    private T data;
+
+    private String message;
+
+}

--- a/src/main/java/com/alkemy/paypocket/services/AccountService.java
+++ b/src/main/java/com/alkemy/paypocket/services/AccountService.java
@@ -1,6 +1,9 @@
 package com.alkemy.paypocket.services;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
+import com.alkemy.paypocket.message.ResponseData;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +33,28 @@ public class AccountService {
         accountRepository.save(newAccount);
 
         return newAccount;
+    }
+
+    public ResponseData<Account> updateAccount(AccountDto accountDto, Integer id) {
+
+        Optional<Account> optionalAccount = accountRepository.findById(id);
+        if (optionalAccount.isPresent()) {
+            try {
+                Account existingAccount = optionalAccount.get();
+
+                existingAccount.setTransactionLimit(accountDto.getTransactionLimit());
+
+                existingAccount.setUpdateDate(LocalDate.now());
+                accountRepository.save(existingAccount);
+
+                return new ResponseData<>(existingAccount, "Actualizacion exitosa");
+            } catch (Exception e) {
+                e.printStackTrace();
+                return new ResponseData<>(null, "Error al actualizar la cuenta");
+            }
+        } else {
+            return new ResponseData<>(null, "Cuenta no encontrada");
+        }
     }
 
 }


### PR DESCRIPTION
Se realizo el endpoint solicitado, pudiendo actualizar solo el transactionLimit de una cuenta, luego de verificar su existencia.
Ademas, se hizo handle de errores para poder mostrar correctamente el mensaje de lo sucedido (ya sea un status 200 o 400)